### PR TITLE
fix missing call to snmp_store_needed()

### DIFF
--- a/agent/helpers/watcher.c
+++ b/agent/helpers/watcher.c
@@ -319,6 +319,8 @@ netsnmp_watcher_helper_handler(netsnmp_mib_handler *handler,
         break;
 
     case MODE_SET_COMMIT:
+        DEBUGMSG(("helper:watcher", "call snmp_store_needed()\n"));
+        snmp_store_needed(NULL);        //TBD may be not needed, but snmp_mib and system_mib needs this! ck
         break;
 #endif /* NETSNMP_NO_WRITE_SUPPORT */
 

--- a/agent/mibgroup/mibII/snmp_mib.c
+++ b/agent/mibgroup/mibII/snmp_mib.c
@@ -11,7 +11,9 @@
 netsnmp_feature_require(check_vb_truthvalue)
 #endif /* NETSNMP_NO_WRITE_SUPPORT */
 
-static const oid snmp_oid[] = { 1, 3, 6, 1, 2, 1, 11 };
+#define SNMP_OID 1, 3, 6, 1, 2, 1, 11
+
+static const oid snmp_oid[] = { SNMP_OID };
 
 extern long snmp_enableauthentraps;
 extern int snmp_enableauthentrapsset;
@@ -40,8 +42,9 @@ handle_truthvalue(netsnmp_mib_handler *handler,
         int res = netsnmp_check_vb_truthvalue(requests->requestvb);
         if (res != SNMP_ERR_NOERROR)
             netsnmp_request_set_error(requests, res);
+            return res;
     }
-#endif /* NETSNMP_NO_WRITE_SUPPORT */
+#endif /* !NETSNMP_NO_WRITE_SUPPORT */
     return SNMP_ERR_NOERROR;
 }
 
@@ -64,8 +67,8 @@ handle_snmp(netsnmp_mib_handler *handler,
 	    switch(idx) {
 	    case 7:
 	    case 23:
-            case 30:
-		netsnmp_set_request_error(reqinfo, requests,
+	    case 30:
+		    netsnmp_set_request_error(reqinfo, requests,
 					  SNMP_NOSUCHOBJECT);
 		break;
 	    default:
@@ -102,12 +105,13 @@ init_snmp_mib(void)
     DEBUGMSGTL(("snmp", "Initializing\n"));
 
     netsnmp_register_scalar_group(
-      netsnmp_create_handler_registration(
-	"mibII/snmp", handle_snmp, snmp_oid, OID_LENGTH(snmp_oid),
-	HANDLER_CAN_RONLY), 1, 32);
+        netsnmp_create_handler_registration(
+            "mibII/snmp", handle_snmp, snmp_oid, OID_LENGTH(snmp_oid),
+            HANDLER_CAN_RONLY),
+        1, 32);
     {
-        const oid snmpEnableAuthenTraps_oid[] = { 1, 3, 6, 1, 2, 1, 11, 30, 0 };
-	static netsnmp_watcher_info enableauthen_info;
+        const oid snmpEnableAuthenTraps_oid[] = { SNMP_OID, 30, 0 };
+        static netsnmp_watcher_info enableauthen_info;
         netsnmp_handler_registration *reg =
             netsnmp_create_update_handler_registration(
                 "mibII/snmpEnableAuthenTraps",
@@ -118,7 +122,7 @@ init_snmp_mib(void)
         netsnmp_register_watched_instance(
             reg,
             netsnmp_init_watcher_info(
-		&enableauthen_info,
+                &enableauthen_info,
                 &snmp_enableauthentraps, sizeof(snmp_enableauthentraps),
                 ASN_INTEGER, WATCHER_FIXED_SIZE));
     }

--- a/agent/mibgroup/mibII/system_mib.c
+++ b/agent/mibgroup/mibII/system_mib.c
@@ -355,9 +355,9 @@ init_system_mib(void)
         const oid sysContact_oid[] = { 1, 3, 6, 1, 2, 1, 1, 4 };
         static netsnmp_watcher_info sysContact_winfo;
 #ifndef NETSNMP_NO_WRITE_SUPPORT
-        netsnmp_register_watched_scalar(
+        netsnmp_register_watched_scalar(        // FIXME how to trigger snmp_store_needed() after commit
             netsnmp_create_update_handler_registration(
-                "mibII/sysContact", sysContact_oid, OID_LENGTH(sysContact_oid), 
+                "mibII/sysContact", sysContact_oid, OID_LENGTH(sysContact_oid),
                 HANDLER_CAN_RWRITE, &sysContactSet),
             netsnmp_init_watcher_info(
                 &sysContact_winfo, sysContact, SYS_STRING_LEN - 1,
@@ -376,7 +376,7 @@ init_system_mib(void)
         const oid sysName_oid[] = { 1, 3, 6, 1, 2, 1, 1, 5 };
         static netsnmp_watcher_info sysName_winfo;
 #ifndef NETSNMP_NO_WRITE_SUPPORT
-        netsnmp_register_watched_scalar(
+        netsnmp_register_watched_scalar(        // FIXME how to trigger snmp_store_needed() after commit
             netsnmp_create_update_handler_registration(
                 "mibII/sysName", sysName_oid, OID_LENGTH(sysName_oid),
                 HANDLER_CAN_RWRITE, &sysNameSet),
@@ -397,7 +397,7 @@ init_system_mib(void)
         const oid sysLocation_oid[] = { 1, 3, 6, 1, 2, 1, 1, 6 };
         static netsnmp_watcher_info sysLocation_winfo;
 #ifndef NETSNMP_NO_WRITE_SUPPORT
-        netsnmp_register_watched_scalar(
+        netsnmp_register_watched_scalar(        // FIXME how to trigger snmp_store_needed() after commit
             netsnmp_create_update_handler_registration(
                 "mibII/sysLocation", sysLocation_oid,
                 OID_LENGTH(sysLocation_oid),

--- a/agent/mibgroup/mibII/updates.c
+++ b/agent/mibgroup/mibII/updates.c
@@ -9,12 +9,17 @@ handle_updates(netsnmp_mib_handler *handler,
                netsnmp_request_info *requests)
 {
     int *set = (int*)handler->myvoid;
+    DEBUGMSG(("helper:handle_updates", "\n"));
 
 #ifndef NETSNMP_NO_WRITE_SUPPORT
-    if (reqinfo->mode == MODE_SET_RESERVE1 && *set < 0)
+    if (reqinfo->mode == MODE_SET_RESERVE1 && *set < 0) {
         netsnmp_request_set_error(requests, SNMP_ERR_NOTWRITABLE);
-    else if (reqinfo->mode == MODE_SET_COMMIT)
+        return SNMP_ERR_NOTWRITABLE;
+    }
+    else if (reqinfo->mode == MODE_SET_COMMIT) {
+        DEBUGMSG(("helper:handle_updates", "set value\n"));
         *set = 1;
+    }
 #endif /* NETSNMP_NO_WRITE_SUPPORT */
     return SNMP_ERR_NOERROR;
 }


### PR DESCRIPTION
The writeable scalars of system_mib and snmp_mib dit not trigger
the snmp_store to save the value after commit.
The netsnmp_watcher_helper_handler() do now call snmp_store_needed()
after commit. This may be not always needed,
but at least snmp_mib and system_mib needs this!

The netsnmp_inject_handler() is not longer used, it prevents setting
of snmp_enableauthentrapsset, which is needed to save persistence value.
